### PR TITLE
Investigate how to extract internal Backstage data and ingest it into Akrivis

### DIFF
--- a/akrivis-ingestor/src/main/java/org/kie/akrivis/clients/BackstageClientImpl.java
+++ b/akrivis-ingestor/src/main/java/org/kie/akrivis/clients/BackstageClientImpl.java
@@ -1,0 +1,25 @@
+package org.kie.akrivis.clients;
+
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.kie.akrivis.scheduler.IngestorHttpClient;
+
+public class BackstageClientImpl implements IngestorHttpClient {
+
+    @Override
+    public String fetchData(String url) {
+
+        try (Client client = ClientBuilder.newClient()) {
+            return client.
+                    target(getBackstageHome() + url).
+                    request(MediaType.APPLICATION_JSON).
+                    get(String.class);
+        }
+    }
+
+    private String getBackstageHome() {
+        return ConfigProvider.getConfig().getValue("akrivis.backstage.address", String.class);
+    }
+}

--- a/akrivis-ingestor/src/main/java/org/kie/akrivis/scheduler/IngestorHttpClient.java
+++ b/akrivis-ingestor/src/main/java/org/kie/akrivis/scheduler/IngestorHttpClient.java
@@ -1,5 +1,6 @@
 package org.kie.akrivis.scheduler;
 
+import org.kie.akrivis.clients.BackstageClientImpl;
 import org.kie.akrivis.clients.DefaultClientImpl;
 import org.kie.akrivis.clients.GitHubClientImpl;
 import org.kie.akrivis.clients.MockGithubClientImpl;
@@ -12,6 +13,7 @@ public interface IngestorHttpClient {
     static IngestorHttpClient findHttpClient(String type) {
         return switch (type) {
             case "GitHub" -> new GitHubClientImpl();
+            case "Backstage" -> new BackstageClientImpl();
             case "Default" -> new DefaultClientImpl();
             case "GitHubMock" -> new MockGithubClientImpl();
             default -> throw new UnsupportedOperationException("Unknown type: " + type);

--- a/akrivis-ingestor/src/main/java/org/kie/akrivis/scheduler/JobExecutor.java
+++ b/akrivis-ingestor/src/main/java/org/kie/akrivis/scheduler/JobExecutor.java
@@ -31,12 +31,6 @@ public class JobExecutor {
         final Optional<RawData> latest = jobRepository.findLatestRawDataByJobId(jobPersisted.id);
         final String data = client.fetchData(jobPersisted.endpoint);
 
-
-
-
-
-
-
         if (latest.isPresent() && jsonEquals(data, latest.get().data)) {
             jobRepository.persist(jobPersisted);
             return latest.get();

--- a/akrivis-ingestor/src/main/resources/application.properties
+++ b/akrivis-ingestor/src/main/resources/application.properties
@@ -4,6 +4,8 @@
 # This force is needed or the scheduler does not run
 quarkus.scheduler.start-mode=forced
 
+%dev.akrivis.backstage.address=http://localhost:7007/api/catalog
+
 # Connects to a shared Postgresql database that is started with instructions in the root README
 %dev.quarkus.datasource.db-kind=postgresql
 %dev.quarkus.datasource.username=sarah

--- a/akrivis-ingestor/src/test/java/org/kie/akrivis/scheduler/IngestorHttpClientTest.java
+++ b/akrivis-ingestor/src/test/java/org/kie/akrivis/scheduler/IngestorHttpClientTest.java
@@ -1,0 +1,24 @@
+package org.kie.akrivis.scheduler;
+
+import org.junit.jupiter.api.Test;
+import org.kie.akrivis.clients.BackstageClientImpl;
+import org.kie.akrivis.clients.DefaultClientImpl;
+import org.kie.akrivis.clients.GitHubClientImpl;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class IngestorHttpClientTest {
+
+    @Test
+    public void testExisting() {
+        assertInstanceOf(GitHubClientImpl.class, IngestorHttpClient.findHttpClient("GitHub"));
+        assertInstanceOf(BackstageClientImpl.class, IngestorHttpClient.findHttpClient("Backstage"));
+        assertInstanceOf(DefaultClientImpl.class, IngestorHttpClient.findHttpClient("Default"));
+    }
+
+    @Test
+    public void testMissing() {
+        assertThrows(UnsupportedOperationException.class, () -> IngestorHttpClient.findHttpClient("Missing"));
+    }
+}

--- a/examples/example-files/scorecards/backstage/configuration.yml
+++ b/examples/example-files/scorecards/backstage/configuration.yml
@@ -1,0 +1,11 @@
+name: Backstage Component Data
+api: /entities/by-query?filter=kind=component
+outputs:
+  - name: Number of Components
+    from: totalItems
+  - name: Data
+    from: akrivis.data
+max value: 100
+thresholds:
+  - name: Good
+    limit: 50

--- a/examples/example-files/scorecards/backstage/level-score.yard.yml
+++ b/examples/example-files/scorecards/backstage/level-score.yard.yml
@@ -1,0 +1,18 @@
+specVersion: alpha
+kind: YaRD
+name: 'Project Statistics'
+inputs:
+  - name: Number of Components
+    type: number
+elements:
+  - name: Result
+    type: Decision
+    logic:
+      type: DecisionTable
+      hitPolicy: FIRST
+      inputs: ['Number of Components']
+      outputComponents: ['Score']
+      rules:
+        - ['<=1', 0]
+        - ['<=2', 50]
+        - ['>=3', 100]


### PR DESCRIPTION
Ticket #35

Utilises the Backstage REST API. This gives information about the different components and resources the components have.

The ticket asks for user data. We can get users, but not login data since that is tracked by the authorization tool. However we can provide an easy access to it in another task.

There is a separate ticket for database access. So this does not cover it.

The example below works. I tried to make more, but ran into issues and I have opened tickets for them.

My original plan was to automatically detect the Backstage location, but the link from Akrivis to Backstage is up to kubernetes settings. So ended up going with just a property for this setup. 